### PR TITLE
Switch to neovim's `notify` API

### DIFF
--- a/lua/encourage.lua
+++ b/lua/encourage.lua
@@ -15,42 +15,12 @@ local default_encouragements = {
   "Nailed it. 🔨",
 }
 
-local function show_floating_message(message)
-  local width = #message
-  local height = 1
-  local buf = vim.api.nvim_create_buf(false, true)
-  local win_height = vim.api.nvim_get_option("lines")
-  local win_width = vim.api.nvim_get_option("columns")
-
-  local opts = {
-    style = "minimal",
-    relative = "editor",
-    width = width,
-    height = height,
-    row = win_height - height - 4,
-    col = win_width - width - 2,
-    border = "rounded",
-  }
-
-  local win = vim.api.nvim_open_win(buf, false, opts)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, {" " .. message .. " "})
-
-  -- Use FloatBorder for the border color
-  vim.api.nvim_win_set_option(win, "winhl", "Normal:NormalFloat,FloatBorder:FloatBorder")
-
-  -- Set a timer to close the window after 5 seconds
-  vim.defer_fn(function()
-    if vim.api.nvim_win_is_valid(win) then
-      vim.api.nvim_win_close(win, true)
-    end
-  end, 5000)
-end
-
+---Chooses a random message and displays it using the notify API
+---@param encouragements string[]
 local function custom_write_message(encouragements)
-  -- Choose a random message
   local message = encouragements[math.random(#encouragements)]
-  -- Display the custom message in a floating window
-  show_floating_message(message)
+  -- The third parameter is ignored by default, unless you have a plugin like `nvim-notify`
+  vim.notify(message, nil, { title = "encourage.nvim" } )
 end
 
 function M.setup(opts)


### PR DESCRIPTION
Cool plugin!

Noticed you mentioned on Reddit that you would look into the `notify` API; here's a good idea of what that might look like. Works well paired with a plugin like [rcarriga/nvim-notify](https://github.com/rcarriga/nvim-notify):

![image](https://github.com/user-attachments/assets/22c9bc21-c740-4d0d-95cf-8b1d99b9573c)

This should reduce the complexity of maintaining a custom windowing function by a lot.